### PR TITLE
Updated the logo-universal.svg to have white as secondary color

### DIFF
--- a/assets/img/logo-universal.svg
+++ b/assets/img/logo-universal.svg
@@ -3,7 +3,7 @@
         <style>
             * {
                 --hackumass-color: #7494ea;
-                --secondary-color: #000000;
+                --secondary-color: #ffffff;
             }
 
             .cls-1,


### PR DESCRIPTION
- Changed the SVG file to have a white secondary color i.e. "UMASS" portion is now in white instead of the earlier black (fixes #31)