### PR TITLE
Enabled popup for telling applicants that HackUMass IX applications will open soon

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -63,4 +63,9 @@
    justify-content: center;
 }
 
-
+.absolute-center {
+  position: absolute; 
+  top: 50%; 
+  left: 50%; 
+  transform: translate(-50%, -50%) !important;
+}

--- a/index.html
+++ b/index.html
@@ -190,10 +190,9 @@
 
    
   <button type="button" hidden="true" class="btn btn-primary" data-toggle="modal" data-target="#covidModal" id="modalOpen">Open modal</button>
-
-  <!--
+  
   <div class="modal fade" id="covidModal" tabindex="-1" role="dialog" style="display: none;" aria-hidden="true">
-    <div class="modal-dialog modal-lg" role="document">
+    <div class="modal-dialog modal-lg" role="document" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
       <div class="modal-content">
 
         <div class="modal-body">
@@ -201,31 +200,44 @@
             <span aria-hidden="true">×</span>
           </button>
 
-          <p class="h3">HackUMass VIII Is On!</p>
-          <p class="lead">
-            We will be hosting HackUMass VIII this year from December 18th -> December 20th</p>
-          <br>
-          <p class="lead">
-            To get started with the application process, go to <a href="http://dashboard.hackumass.com/">the HackUMass Dashboard</a> and create an account. 
-            All participants must re-register new accounts. Accounts from previous years have been deactivated.
-          </p>
-
-          <br>
-
-          <h3>
-            <b>Event Application for HackUMass VIII Are Closed.</b>
-          </h3>
-          <h6>Thank you all for applying! We hope to have a great event this year. If you are unable to attend then we hope to welcome you all back to HackUMass IX next year.</h6>
-          <br>
-          <p class="lead">
-            If you have any questions, message us at <a href="mailto: team@hackumass.com">team@hackumass.com</a>. 
-          </p>
+          <!-- Event Application is Coming Soon -->
+            <h3>
+              <b>HackUMass IX Is Coming Soon!</b>
+            </h3>
+            <p class="lead">
+              We will be hosting HackUMass IX this year from November 5th - 7th. Applications will be opening shortly!
+            </p>
+            <p class="lead">
+              If you have any questions, message us at <a href="mailto: team@hackumass.com">team@hackumass.com</a>.
+            </p>
+            <!-- Event Application is Online -->
+            <!-- <br>
+            <h3>
+              <b>HackUMass IX Is On!</b>
+            </h3>
+            <p class="lead">
+              We are hosting HackUMass IX from November 5th - 7th, 2021.
+            </p>
+            <br>
+            <p class="lead">
+              To get started with the application process, go to the <a href="http://dashboard.hackumass.com/">HackUMass Dashboard</a> and create an account.
+              All participants must re-register new accounts. Accounts from previous years have been deactivated.
+            </p> -->
+            <!-- Event Application Deadline Crossed -->
+            <!-- <br>
+            <h3>
+              <b>Event Application for HackUMass IX Are Closed.</b>
+            </h3>
+            <h6>Thank you all for applying! We hope to have a great event this year. If you are unable to attend then we hope to welcome you all back to HackUMass X next year.</h6>
+            <br>
+            <p class="lead">
+              If you have any questions, message us at <a href="mailto: team@hackumass.com">team@hackumass.com</a>.
+            </p> -->
 
         </div>
       </div>
     </div>
   </div>
-  -->
 
     <section class="section" style="padding-bottom: 0">
         <div class="container">
@@ -866,10 +878,10 @@
 
 
   <script>
-    // Modal Disabled
-    //$(document).ready(function() {
-    //  $("#modalOpen").trigger('click');
-    //});
+    // Modal Enabled
+    $(document).ready(function() {
+    $("#modalOpen").trigger('click');
+    });
   </script>
 
 

--- a/index.html
+++ b/index.html
@@ -192,7 +192,7 @@
   <button type="button" hidden="true" class="btn btn-primary" data-toggle="modal" data-target="#covidModal" id="modalOpen">Open modal</button>
   
   <div class="modal fade" id="covidModal" tabindex="-1" role="dialog" style="display: none;" aria-hidden="true">
-    <div class="modal-dialog modal-lg" role="document" style="position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%);">
+    <div class="modal-dialog modal-lg absolute-center" role="document">
       <div class="modal-content">
 
         <div class="modal-body">


### PR DESCRIPTION
This pull request enables the popup for telling applicants that HackUMass IX applications will open soon (fixes #18), with the following changelog:
- Enabled pre-existing modal (logic written within a <script> tag)
- Modified popup to display applications will open soon
- Centered modal with absolute positioning
- Added commented portions for quick change between various statuses ("Event Application is Coming Soon", "Event Application is Online", "Event Application Deadline Crossed").