### PR TITLE
Commented out the MLH banner till HUM-IX affiliates with MLH again

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,12 +139,13 @@
 
       <div class="topbar-left">
         <!-- For now, nothing on the left bar of the top bar -->
-        <a id="mlh-trust-badge"
+        <!-- Enable banner if HackUMass IX affiliates with MLH again-->
+        <!-- <a id="mlh-trust-badge"
           style="display:block;max-width:100px;min-width:60px;position:fixed;left:50px;top:0;width:10%;z-index:10000"
           href="https://mlh.io/seasons/2021/events?utm_source=na-hackathon&utm_medium=TrustBadge&utm_campaign=2021-season&utm_content=blue"
           target="_blank"><img
             src="https://s3.amazonaws.com/logged-assets/trust-badge/2021/mlh-trust-badge-2021-blue.svg"
-            alt="Major League Hacking 2021 Hackathon Season" style="width:100%"></a>
+            alt="Major League Hacking 2021 Hackathon Season" style="width:100%"></a> -->
 
         <!-- Enable banner if Pinnacle collaboration is on for HUM-IX-->
         <!-- <a id="pinnacle-badge" style="display:block;max-width:100px;min-width:60px;position:fixed;left:200px;top:0;width:10%;z-index:10000" href="https://pinnacle.us.org/" target="_blank"><img src="assets/img/partners/pinnacle_badge.png" alt="Pinnacle" style="width:100%"></a> -->


### PR DESCRIPTION
- Hid the MLH banner temporarily on the website since HUM-IX is technically not on the MLH list yet (we can’t send them our website with their banner already in it) 