### PR TITLE
Updated the projects display to HackUMass IX projects on landing page

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -20,6 +20,11 @@
     }
 }
 
+body {
+    margin: 0 !important;
+    padding: 0 !important;
+}
+
 h1,
 h2,
 h3,

--- a/index.html
+++ b/index.html
@@ -202,8 +202,7 @@
           <br>
           <p class="lead text-white fs-20">November 5th - 7th, 2021 | 36 Hours | Amherst, MA and Online</p>
           <a id="home-button" class="btn btn-xl btn-round btn-default " style="color:black"
-            href="https://fuseumass.github.io/HackUMass-VIII-Projects/public%3Fwinners=1.html">View HackUMass VIII
-            Projects</a>
+            href="https://dashboard.hackumass.com/projects/public">View HackUMass IX Projects</a>
 
         </div>
       </div>


### PR DESCRIPTION
## Code Changelog

Changed fragment from:
```HTML
<a id="home-button" class="btn btn-xl btn-round btn-default " style="color:black" href="https://fuseumass.github.io/HackUMass-VIII-Projects/public%3Fwinners=1.html">View HackUMass VIII Projects</a>
```
to:
```HTML
<a id="home-button" class="btn btn-xl btn-round btn-default " style="color:black" href="https://dashboard.hackumass.com/projects/public">View HackUMass IX Projects</a>
```

## Views

### Original

![Screen Shot 2022-03-22 at 6 06 31 PM](https://user-images.githubusercontent.com/20084950/159584686-82138338-92c9-48c2-9f76-2e8078b07f51.png)
![Screen Shot 2022-03-22 at 6 06 56 PM](https://user-images.githubusercontent.com/20084950/159584690-4517cfde-c0e4-4fce-906d-e6c624fdfe7f.png)

### Updated

![Screen Shot 2022-03-22 at 6 06 40 PM](https://user-images.githubusercontent.com/20084950/159584725-3d93ca25-ace1-43a7-a4d5-ae35e62ee65d.png)
![Screen Shot 2022-03-22 at 6 07 03 PM](https://user-images.githubusercontent.com/20084950/159584726-afc646e9-aa75-4eb0-a593-7e8fd0056514.png)
