### PR TITLE
Fixing image URL for 2 team members

### DIFF
--- a/index.html
+++ b/index.html
@@ -883,7 +883,7 @@
                 <h6 class="team-role">Member, Hardware</h6>
               </div>
               <div class="col-lg-3 col-md-6 col-sm-12 text-center">
-                <img class="rounded-circle shadow-2 img-border object-fit-cover" src="assets/img/team/daniel_kang.jpg"
+                <img class="rounded-circle shadow-2 img-border object-fit-cover" src="assets/img/team/daniel_kang.JPG"
                   alt="Dong Hyun Kang" />
                 <h5 class="primary-color">Dong Hyun Kang</h5>
                 <h6 class="team-role">Member, Hardware</h6>
@@ -943,7 +943,7 @@
                 <h6 class="team-role">Member, Hardware</h6>
               </div>
               <div class="col-lg-3 col-md-6 col-sm-12 text-center">
-                <img class="rounded-circle shadow-2 img-border object-fit-cover" src="assets/img/team/ruchi_gupta.jpg"
+                <img class="rounded-circle shadow-2 img-border object-fit-cover" src="assets/img/team/ruchi_gupta.JPG"
                   alt="Ruchi Gupta" />
                 <h5 class="primary-color">Ruchi Gupta</h5>
                 <h6 class="team-role">Member, Logistics/Sponsorship</h6>


### PR DESCRIPTION
- Changing url to .JPG for two team members to reflect their images and fix bug
- Current issue:
<img width="484" alt="image" src="https://user-images.githubusercontent.com/54553038/197237406-650930b2-a96f-4e94-8731-019def21b041.png">
<img width="422" alt="image" src="https://user-images.githubusercontent.com/54553038/197237431-71f9884d-d306-4e87-bd7c-78508918dde4.png">

Fix:
- 
<img width="449" alt="image" src="https://user-images.githubusercontent.com/54553038/197237472-8fb91dbf-1f31-4cf9-8724-13d663c0a829.png">
<img width="432" alt="image" src="https://user-images.githubusercontent.com/54553038/197237490-c067dd88-4904-4192-93f4-41b7cf9e6cde.png">
