### PR TITLE
Removed Ladies Storm Hackathon in "Creative Hackers" and changed sponsor contact email to team@hackumass.com 

### DIFF
--- a/index.html
+++ b/index.html
@@ -547,8 +547,7 @@
                 diverse backgrounds. Veteran hackers, first-timers, developers,
                 engineers, entrepreneurs, and even non-tech majors -- this is
                 who we are. Our goal is to bring together and inspire hackers
-                from every background and provide opportunities like Ladies
-                Storm Hackathons to continue growing in diversity. Come with
+                from every background and provide opportunities to continue growing in diversity. Come with
                 friends, make new friends, join 800 other participants in one of
                 the biggest and best hackathons in New England.
               </p>
@@ -1323,7 +1322,7 @@
               Let us know! Email us anytime at
               <a href="mailto:team@hackumass.com">team@hackumass.com</a>
               <!--or if your company is interested in sponsoring us, email us at
-            <a href="mailto:sponsors@hackumass.com">sponsors@hackumass.com</a>-->
+            <a href="mailto:team@hackumass.com">team@hackumass.com</a>-->
             </p>
           </header>
         </div>


### PR DESCRIPTION
resolves #191 by removing Ladies Storm Hackathon in "Creative Hackers" and changing sponsor contact email to team@hackumass.com 

Signed-off-by: Eli Mullan <elimullan21@gmail.com>